### PR TITLE
move node.id generation to presto-start .sh

### DIFF
--- a/presto/files/create-configs.sh
+++ b/presto/files/create-configs.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 # Node properties
+# "__uuidgen__" is a placeholder to be replaced when container starts. 
+# Using "node.id=(uuidgen)"" here would cause duplicate node ID problem in multi-node setup
 cat > $PRESTO_DIR/etc/node.properties <<EOF
 node.environment=production
-node.id=`uuidgen`
+node.id=__uuidgen__
 node.data-dir=$PRESTO_DATA_DIR
 EOF
 

--- a/presto/files/presto-start.sh
+++ b/presto/files/presto-start.sh
@@ -12,6 +12,9 @@ sed -i -e "s#ADLS_CLIENT_SECRET#${ADLS_CLIENT_SECRET}#g" $config
 sed -i -e "s/AZURE_STORAGE_ACCOUNT_NAME/${AZURE_STORAGE_ACCOUNT_NAME}/g" $config
 sed -i -e "s#AZURE_STORAGE_ACCOUNT_KEY#${AZURE_STORAGE_ACCOUNT_KEY}#g" $config
 
+# generate unique node.id
+sed -i -e "s/__uuidgen__/$(uuidgen)/g" $PRESTO_DIR/etc/node.properties
+
 # Create additional catalogs...
 
 # Azure CosmosDB with MongoAPI


### PR DESCRIPTION
Generating node.id value at Docker image build time may cause duplicate node ID problem in multi-node Presto setup (I was scratching my head for a while last night). Moving the process to presto-start.sh can guarantee the uniqueness of the node ID. 