### PR TITLE
fix jdk 8 & jar lib files download error in Dockerfile

### DIFF
--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -4,29 +4,28 @@ ENV HIVE_VERSION=1.2.2
 ENV HIVE_HOME=/usr/local/hive
 ENV PATH=$HIVE_HOME/bin:$PATH
 
+RUN yum -y install wget
+
 # Download hive
-RUN curl -s -O http://apache.claz.org/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-bin.tar.gz && \
+RUN wget https://apache.claz.org/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-bin.tar.gz && \
 	tar -zxf ./apache-hive-${HIVE_VERSION}-bin.tar.gz && \
 	mv ./apache-hive-${HIVE_VERSION}-bin $HIVE_HOME && \
 	rm -f ./apache-hive-${HIVE_VERSION}-bin.tar.gz
 
 # Download specific jars needed for ADLS and WASB and not included in Hive
 RUN cd $HIVE_HOME/lib && \
-	curl -O http://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.6.0/jackson-core-2.6.0.jar && \
-	curl -O http://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/2.0.0/azure-storage-2.0.0.jar && \
-    curl -O http://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/2.7.3/hadoop-azure-2.7.3.jar && \
-	curl -O http://repo1.maven.org/maven2/com/microsoft/azure/azure-data-lake-store-sdk/2.1.5/azure-data-lake-store-sdk-2.1.5.jar && \
-    curl -O http://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure-datalake/3.0.0-alpha3/hadoop-azure-datalake-3.0.0-alpha3.jar
+	wget https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.6.0/jackson-core-2.6.0.jar && \
+	wget https://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/3.1.0/azure-storage-3.1.0.jar && \
+    wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/2.7.3/hadoop-azure-2.7.3.jar && \
+	wget https://repo1.maven.org/maven2/com/microsoft/azure/azure-data-lake-store-sdk/2.1.5/azure-data-lake-store-sdk-2.1.5.jar && \
+    wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure-datalake/3.0.0-alpha3/hadoop-azure-datalake-3.0.0-alpha3.jar
 
 # Uninstall JDK 1.7 that was installed in the base image
 # Install JDK 1.8 since Azure Data Lake Store JARs are compiled using JDK 1.8
-RUN yum erase -y jdk 
-
-RUN yum -y install wget
-
-RUN  wget -c --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm && \
-        rpm -i jdk-8u131-linux-x64.rpm && \
-        rm jdk-8u131-linux-x64.rpm
+RUN yum erase -y jdk && \ 
+	wget -c --header "Cookie: oraclelicense=accept-securebackup-cookie" https://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm && \
+    rpm -i jdk-8u131-linux-x64.rpm && \
+    rm jdk-8u131-linux-x64.rpm
 
 EXPOSE 9083
 

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -20,10 +20,13 @@ RUN cd $HIVE_HOME/lib && \
 
 # Uninstall JDK 1.7 that was installed in the base image
 # Install JDK 1.8 since Azure Data Lake Store JARs are compiled using JDK 1.8
-RUN yum erase -y jdk && \
-	curl -s -LO 'http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && \
-	rpm -i jdk-8u131-linux-x64.rpm && \
-	rm jdk-8u131-linux-x64.rpm
+RUN yum erase -y jdk 
+
+RUN yum -y install wget
+
+RUN  wget -c --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm && \
+        rpm -i jdk-8u131-linux-x64.rpm && \
+        rm jdk-8u131-linux-x64.rpm
 
 EXPOSE 9083
 

--- a/presto/Dockerfile
+++ b/presto/Dockerfile
@@ -34,12 +34,12 @@ RUN mkdir -p $PRESTO_DIR && \
 # Download specific jars needed for ADLS and WASB and not included in Presto
 # hadoop-azure-2.7.3.jar depends on azure-storage-2.0.0.jar since it implements the startCopyFromBlob which was removed from later versions
 RUN cd $PRESTO_DIR/plugin/hive-hadoop2 && \ 
-    curl -O http://repo1.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6.jar && \
-    curl -O http://repo1.maven.org/maven2/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar && \
-    curl -O http://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/2.0.0/azure-storage-2.0.0.jar && \
-    curl -O http://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/2.7.3/hadoop-azure-2.7.3.jar && \
-    curl -O http://repo1.maven.org/maven2/com/microsoft/azure/azure-data-lake-store-sdk/2.1.5/azure-data-lake-store-sdk-2.1.5.jar && \
-    curl -O http://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure-datalake/3.0.0-alpha3/hadoop-azure-datalake-3.0.0-alpha3.jar    
+    curl -s -O https://repo1.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6.jar && \
+    curl -s -O https://repo1.maven.org/maven2/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar && \
+    curl -s -O https://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/3.1.0/azure-storage-3.1.0.jar && \
+    curl -s -O https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/2.7.3/hadoop-azure-2.7.3.jar && \
+    curl -s -O https://repo1.maven.org/maven2/com/microsoft/azure/azure-data-lake-store-sdk/2.1.5/azure-data-lake-store-sdk-2.1.5.jar && \
+    curl -s -O https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure-datalake/3.0.0-alpha3/hadoop-azure-datalake-3.0.0-alpha3.jar  
 
 ADD files /_build/
 
@@ -56,10 +56,5 @@ RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc
 WORKDIR $PRESTO_DIR
 
 CMD /etc/presto-start.sh
-
-
-
-
-
 
 


### PR DESCRIPTION
Download jdk 8u131 is broken , i updated the Dockerfile with the working version using wget
Other java jar files download like hadoop-storage from maven still uses http so it is not working and need to be replaced with https